### PR TITLE
Initial Release of Litter Robot Card!  🤖 💩 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sinon": "^21.1.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "@lit/task": "^1.0.3",

--- a/test/cards/robot/card.spec.ts
+++ b/test/cards/robot/card.spec.ts
@@ -127,9 +127,16 @@ describe('card.ts', () => {
           attributes: {},
         },
       });
-      card.hass = mockHass;
-      expect(card.hasAttribute('cycling')).to.be.true;
-      await fixture(card.render() as TemplateResult);
+      // Reflected attributes flush only after connect; Lit update queue awaits enableUpdating from connectedCallback.
+      document.body.appendChild(card);
+      try {
+        card.hass = mockHass;
+        await card.updateComplete;
+        expect(card.hasAttribute('cycling')).to.be.true;
+        await fixture(card.render() as TemplateResult);
+      } finally {
+        card.remove();
+      }
     });
 
     it('should not set cycling on the card host when status is ready', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,10 +4251,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.9.3:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.2.tgz#0b1bfb15f68c64b97032f3d78abbf98bdbba501f"
+  integrity sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==
 
 undici-types@^7.21.0:
   version "7.24.3"


### PR DESCRIPTION
## Whisker Card — initial release

First public release of **Whisker Card**, a Lovelace card for **Litter-Robot** using Home Assistant’s official [`litterrobot`](https://www.home-assistant.io/integrations/litterrobot/) integration.

![robots](https://github.com/homeassistant-extras/whisker/blob/main/assets/robots.png?raw=true)

**What you get**

- Status header with readable status and icon from `status_code`
- Cycling emphasis while a clean cycle is active
- Vacuum + reset picture controls (tap to act, hold for more-info)
- Menu with Lovelace entity rows for globe light/brightness, panel brightness, and cycle delay when available
- Pet weight chip, litter & waste gauges, last seen when entities exist

![control](https://github.com/homeassistant-extras/whisker/blob/main/assets/control.png?raw=true)


**Setup**

- Configure with a **Litter-Robot device** (`device_id`); optional **title** override.
- **HACS**: add as a custom **Dashboard** repo, install, add the resource if needed.
- **Manual**: use `whisker.js` from this release’s `dist` and register it as a `module` resource.

**Note:** Tested primarily on **Litter-Robot 5 Prop**; other models may work if the integration exposes the same entities—[open an issue](https://github.com/homeassistant-extras/whisker/issues) if something’s off on your model.